### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up an Incident.io connector"
 og:title: "Set up an Incident.io connector"
-description: "C1 provides identity governance and just-in-time provisioning for Incident.io. Integrate your Incident.io instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "C1 provides identity governance and just-in-time provisioning for Incident.io. Integrate your Incident.io instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for Incident.io. Integrate your Incident.io instance with C1 for unified visibility and governance over user access."
+og:description: "C1 provides identity governance for Incident.io. Integrate your Incident.io instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Incident.io"
 ---
 
@@ -33,7 +33,7 @@ Carefully copy and save the API key.
 </Step>
 </Steps> 
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Incident.io connector
 
@@ -86,7 +86,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Incident.io connector is now pulling access data into C1.
+**Done.** Your Incident.io connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -202,6 +202,6 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Incident.io connector is now pulling access data into C1.
+**Done.** Your Incident.io connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines