### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -51,7 +51,6 @@ func (o *UserBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		}
 
 		userTraits := []resource.UserTraitOption{
-			resource.WithUserProfile(profile),
 			resource.WithEmail(user.Email, true),
 		}
 
@@ -61,6 +60,7 @@ func (o *UserBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 			userResourceType,
 			user.ID,
 			userTraits,
+			resource.WithResourceProfile(profile),
 			resource.WithParentResourceID(parentResourceID),
 		)
 		if err != nil {


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Login and
login-alias data stays on `UserTrait` and is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.