### PR TITLE
Guard base_role and custom_role grant emission behind WillSyncResourceType

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -40,6 +40,11 @@
         "displayName": "User",
         "traits": [
           "TRAIT_USER"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
+          }
         ]
       },
       "capabilities": [

--- a/cmd/baton-incident-io/main.go
+++ b/cmd/baton-incident-io/main.go
@@ -40,7 +40,7 @@ func getConnector(ctx context.Context, cfg *config.IncidentIo, opts *cli.Connect
 		return nil, nil, fmt.Errorf("missing access token")
 	}
 
-	cb, err := connector.New(ctx, accessToken)
+	cb, err := connector.New(ctx, accessToken, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -15,6 +15,10 @@ sidebarTitle: "Incident.io"
 | Base roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
 | Custom roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  | 
 
+<Note>
+**Account entitlements.** Accounts carry no entitlements of their own — a user's access is expressed as grants against Base roles and Custom roles. When both are excluded from the sync, the connector skips the account grant pass as well, since the roles those grants point at wouldn't be present.
+</Note>
+
 ## Gather Incident.io credentials 
 
 Each setup method requires you to pass in credentials generated in Incident.io. Gather these credentials before you move on. 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -12,15 +12,15 @@ import (
 )
 
 type IncidentIo struct {
-	apiClient       *client.APIClient
-	syncBaseRoles   bool
-	syncCustomRoles bool
+	apiClient                  *client.APIClient
+	skipBaseRoleResourceType   bool
+	skipCustomRoleResourceType bool
 }
 
 // ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
 func (d *IncidentIo) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		NewUserBuilder(d.apiClient, d.syncBaseRoles, d.syncCustomRoles),
+		NewUserBuilder(d.apiClient, d.skipBaseRoleResourceType, d.skipCustomRoleResourceType),
 		NewScheduleBuilder(d.apiClient),
 		NewBaseRoleBuilder(d.apiClient),
 		NewCustomRoleBuilder(d.apiClient),
@@ -51,12 +51,13 @@ func (d *IncidentIo) Validate(ctx context.Context) (annotations.Annotations, err
 func New(ctx context.Context, accessToken string, opts *cli.ConnectorOpts) (*IncidentIo, error) {
 	apiClient := client.NewClient(accessToken, nil)
 
-	syncBaseRoles := opts.WillSyncResourceType(BaseRoleResourceTypeID)
-	syncCustomRoles := opts.WillSyncResourceType(CustomRoleResourceTypeID)
+	// nil opts means no filter, so nothing is skipped.
+	skipBaseRoleResourceType := opts != nil && !opts.WillSyncResourceType(BaseRoleResourceTypeID)
+	skipCustomRoleResourceType := opts != nil && !opts.WillSyncResourceType(CustomRoleResourceTypeID)
 
 	return &IncidentIo{
-		apiClient:       apiClient,
-		syncBaseRoles:   syncBaseRoles,
-		syncCustomRoles: syncCustomRoles,
+		apiClient:                  apiClient,
+		skipBaseRoleResourceType:   skipBaseRoleResourceType,
+		skipCustomRoleResourceType: skipCustomRoleResourceType,
 	}, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -7,17 +7,20 @@ import (
 	"github.com/conductorone/baton-incident-io/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 )
 
 type IncidentIo struct {
-	apiClient *client.APIClient
+	apiClient       *client.APIClient
+	syncBaseRoles   bool
+	syncCustomRoles bool
 }
 
 // ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
 func (d *IncidentIo) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		NewUserBuilder(d.apiClient),
+		NewUserBuilder(d.apiClient, d.syncBaseRoles, d.syncCustomRoles),
 		NewScheduleBuilder(d.apiClient),
 		NewBaseRoleBuilder(d.apiClient),
 		NewCustomRoleBuilder(d.apiClient),
@@ -45,8 +48,15 @@ func (d *IncidentIo) Validate(ctx context.Context) (annotations.Annotations, err
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, accessToken string) (*IncidentIo, error) {
+func New(ctx context.Context, accessToken string, opts *cli.ConnectorOpts) (*IncidentIo, error) {
 	apiClient := client.NewClient(accessToken, nil)
 
-	return &IncidentIo{apiClient: apiClient}, nil
+	syncBaseRoles := opts.WillSyncResourceType(BaseRoleResourceTypeID)
+	syncCustomRoles := opts.WillSyncResourceType(CustomRoleResourceTypeID)
+
+	return &IncidentIo{
+		apiClient:       apiClient,
+		syncBaseRoles:   syncBaseRoles,
+		syncCustomRoles: syncCustomRoles,
+	}, nil
 }

--- a/pkg/connector/integration_test.go
+++ b/pkg/connector/integration_test.go
@@ -35,7 +35,7 @@ func initClient(t *testing.T) *client.APIClient {
 func TestUserBuilderList(t *testing.T) {
 	c := initClient(t)
 
-	u := NewUserBuilder(c, true, true)
+	u := NewUserBuilder(c, false, false)
 
 	res, _, err := u.List(ctx, parentResourceID, syncOpts)
 	assert.Nil(t, err)

--- a/pkg/connector/integration_test.go
+++ b/pkg/connector/integration_test.go
@@ -35,7 +35,7 @@ func initClient(t *testing.T) *client.APIClient {
 func TestUserBuilderList(t *testing.T) {
 	c := initClient(t)
 
-	u := NewUserBuilder(c)
+	u := NewUserBuilder(c, true, true)
 
 	res, _, err := u.List(ctx, parentResourceID, syncOpts)
 	assert.Nil(t, err)

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -4,6 +4,11 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
+const (
+	BaseRoleResourceTypeID   = "base-role"
+	CustomRoleResourceTypeID = "custom-role"
+)
+
 var userResourceType = &v2.ResourceType{
 	Id:          "user",
 	DisplayName: "User",
@@ -11,12 +16,12 @@ var userResourceType = &v2.ResourceType{
 }
 
 var baseRoleResourceType = &v2.ResourceType{
-	Id:          "base-role",
+	Id:          BaseRoleResourceTypeID,
 	DisplayName: "base Role",
 }
 
 var customRoleResourceType = &v2.ResourceType{
-	Id:          "custom-role",
+	Id:          CustomRoleResourceTypeID,
 	DisplayName: "custom Role",
 }
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -6,23 +6,27 @@ import (
 
 	"github.com/conductorone/baton-incident-io/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 )
 
 const roleGrantPermission = "assigned"
 
 // userBuilder manages user-related resources.
 type UserBuilder struct {
-	resourceType *v2.ResourceType
-	client       *client.APIClient
+	resourceType    *v2.ResourceType
+	client          *client.APIClient
+	syncBaseRoles   bool
+	syncCustomRoles bool
 }
 
 // ResourceType returns the type of resource managed by this builder.
 func (o *UserBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
-	return userResourceType
+	return o.resourceType
 }
 
 // List retrieves users and converts them into Baton resources.
@@ -102,7 +106,7 @@ func (o *UserBuilder) Grants(ctx context.Context, res *v2.Resource, opts resourc
 	var grants []*v2.Grant
 
 	// BaseRole
-	if user.BaseRole.ID != "" {
+	if o.syncBaseRoles && user.BaseRole.ID != "" {
 		baseRoleResource := &v2.Resource{
 			Id: &v2.ResourceId{
 				ResourceType: baseRoleResourceType.Id,
@@ -119,32 +123,49 @@ func (o *UserBuilder) Grants(ctx context.Context, res *v2.Resource, opts resourc
 	}
 
 	// CustomRoles
-	for _, cr := range user.CustomRoles {
-		if cr.ID == "" {
-			continue
-		}
+	if o.syncCustomRoles {
+		for _, cr := range user.CustomRoles {
+			if cr.ID == "" {
+				continue
+			}
 
-		customRoleResource := &v2.Resource{
-			Id: &v2.ResourceId{
-				ResourceType: customRoleResourceType.Id,
-				Resource:     cr.ID,
-			},
-		}
+			customRoleResource := &v2.Resource{
+				Id: &v2.ResourceId{
+					ResourceType: customRoleResourceType.Id,
+					Resource:     cr.ID,
+				},
+			}
 
-		grant := grant.NewGrant(
-			customRoleResource,
-			roleGrantPermission,
-			res,
-		)
-		grants = append(grants, grant)
+			grant := grant.NewGrant(
+				customRoleResource,
+				roleGrantPermission,
+				res,
+			)
+			grants = append(grants, grant)
+		}
 	}
 
 	return grants, nil, nil
 }
 
-func NewUserBuilder(c *client.APIClient) *UserBuilder {
+func NewUserBuilder(c *client.APIClient, syncBaseRoles, syncCustomRoles bool) *UserBuilder {
+	resourceType := proto.Clone(userResourceType).(*v2.ResourceType)
+	userAnnos := annotations.Annotations(resourceType.GetAnnotations())
+	if !syncBaseRoles && !syncCustomRoles {
+		// Neither cross-synced role type is enabled, so this builder will
+		// never emit a grant -- skip both passes entirely.
+		userAnnos.Update(&v2.SkipEntitlementsAndGrants{})
+	} else {
+		// Users have no entitlements of their own; only the grants pass is
+		// conditional on which role types are being synced.
+		userAnnos.Update(&v2.SkipEntitlements{})
+	}
+	resourceType.Annotations = userAnnos
+
 	return &UserBuilder{
-		resourceType: userResourceType,
-		client:       c,
+		resourceType:    resourceType,
+		client:          c,
+		syncBaseRoles:   syncBaseRoles,
+		syncCustomRoles: syncCustomRoles,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -93,15 +93,13 @@ func (o *UserBuilder) Entitlements(_ context.Context, res *v2.Resource, opts res
 }
 
 // Role grants are implemented here for performance reasons.
+//
+// The cross-type emission is gated per role type below, but there is no
+// combined early return: when both role types are excluded, NewUserBuilder
+// annotates this resource type SkipEntitlementsAndGrants and the SDK never
+// calls Grants() at all (see shouldSkipEntitlementsAndGrants in the SDK's
+// pkg/sync/syncer.go), so guarding again here would be unreachable.
 func (o *UserBuilder) Grants(ctx context.Context, res *v2.Resource, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
-	if o.skipBaseRoleResourceType && o.skipCustomRoleResourceType {
-		// Every grant target is excluded from the sync, so skip the per-user
-		// fetch entirely rather than discarding its result below. The
-		// SkipEntitlementsAndGrants annotation normally stops the SDK before
-		// it reaches here; this keeps the guard self-contained.
-		return nil, nil, nil
-	}
-
 	l := ctxzap.Extract(ctx)
 	userID := res.Id.Resource
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -18,10 +18,10 @@ const roleGrantPermission = "assigned"
 
 // userBuilder manages user-related resources.
 type UserBuilder struct {
-	resourceType    *v2.ResourceType
-	client          *client.APIClient
-	syncBaseRoles   bool
-	syncCustomRoles bool
+	resourceType               *v2.ResourceType
+	client                     *client.APIClient
+	skipBaseRoleResourceType   bool
+	skipCustomRoleResourceType bool
 }
 
 // ResourceType returns the type of resource managed by this builder.
@@ -106,7 +106,7 @@ func (o *UserBuilder) Grants(ctx context.Context, res *v2.Resource, opts resourc
 	var grants []*v2.Grant
 
 	// BaseRole
-	if o.syncBaseRoles && user.BaseRole.ID != "" {
+	if !o.skipBaseRoleResourceType && user.BaseRole.ID != "" {
 		baseRoleResource := &v2.Resource{
 			Id: &v2.ResourceId{
 				ResourceType: baseRoleResourceType.Id,
@@ -123,7 +123,7 @@ func (o *UserBuilder) Grants(ctx context.Context, res *v2.Resource, opts resourc
 	}
 
 	// CustomRoles
-	if o.syncCustomRoles {
+	if !o.skipCustomRoleResourceType {
 		for _, cr := range user.CustomRoles {
 			if cr.ID == "" {
 				continue
@@ -148,10 +148,10 @@ func (o *UserBuilder) Grants(ctx context.Context, res *v2.Resource, opts resourc
 	return grants, nil, nil
 }
 
-func NewUserBuilder(c *client.APIClient, syncBaseRoles, syncCustomRoles bool) *UserBuilder {
+func NewUserBuilder(c *client.APIClient, skipBaseRoleResourceType, skipCustomRoleResourceType bool) *UserBuilder {
 	resourceType := proto.Clone(userResourceType).(*v2.ResourceType)
 	userAnnos := annotations.Annotations(resourceType.GetAnnotations())
-	if !syncBaseRoles && !syncCustomRoles {
+	if skipBaseRoleResourceType && skipCustomRoleResourceType {
 		// Neither cross-synced role type is enabled, so this builder will
 		// never emit a grant -- skip both passes entirely.
 		userAnnos.Update(&v2.SkipEntitlementsAndGrants{})
@@ -163,9 +163,9 @@ func NewUserBuilder(c *client.APIClient, syncBaseRoles, syncCustomRoles bool) *U
 	resourceType.Annotations = userAnnos
 
 	return &UserBuilder{
-		resourceType:    resourceType,
-		client:          c,
-		syncBaseRoles:   syncBaseRoles,
-		syncCustomRoles: syncCustomRoles,
+		resourceType:               resourceType,
+		client:                     c,
+		skipBaseRoleResourceType:   skipBaseRoleResourceType,
+		skipCustomRoleResourceType: skipCustomRoleResourceType,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -94,6 +94,14 @@ func (o *UserBuilder) Entitlements(_ context.Context, res *v2.Resource, opts res
 
 // Role grants are implemented here for performance reasons.
 func (o *UserBuilder) Grants(ctx context.Context, res *v2.Resource, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	if o.skipBaseRoleResourceType && o.skipCustomRoleResourceType {
+		// Every grant target is excluded from the sync, so skip the per-user
+		// fetch entirely rather than discarding its result below. The
+		// SkipEntitlementsAndGrants annotation normally stops the SDK before
+		// it reaches here; this keeps the guard self-contained.
+		return nil, nil, nil
+	}
+
 	l := ctxzap.Extract(ctx)
 	userID := res.Id.Resource
 

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"reflect"
@@ -11,8 +12,10 @@ import (
 	"github.com/conductorone/baton-incident-io/pkg/client"
 	"github.com/conductorone/baton-incident-io/pkg/test"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"google.golang.org/protobuf/proto"
 )
 
 var pageOptions = client.PageOptions{
@@ -163,6 +166,22 @@ func TestUserBuilder_Grants_RespectsSyncFilter(t *testing.T) {
 		}
 	})
 
+	t.Run("neither role type synced skips the user fetch", func(t *testing.T) {
+		// A transport that always errors: if Grants still succeeds, it never
+		// issued the per-user request whose result it would have discarded.
+		testClient := test.NewTestClient(nil, errors.New("unexpected API call"))
+		builder := NewUserBuilder(testClient, true, true)
+
+		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
+		if err != nil {
+			t.Fatalf("Expected no API call, got error %v", err)
+		}
+
+		if len(grants) != 0 {
+			t.Errorf("Expected zero grants, got %+v", grants)
+		}
+	})
+
 	t.Run("only base role synced emits only base-role grant", func(t *testing.T) {
 		testClient := newSingleUserTestClient()
 		builder := NewUserBuilder(testClient, false, true)
@@ -179,6 +198,52 @@ func TestUserBuilder_Grants_RespectsSyncFilter(t *testing.T) {
 			t.Errorf("Expected no custom-role grant, got %+v", grants)
 		}
 	})
+}
+
+// The annotations on the user resource type are the mechanism that stops the
+// grants pass (and its per-user fetch) when both role types are excluded, so
+// pin them directly rather than only exercising Grants.
+func TestUserBuilder_ResourceTypeAnnotations(t *testing.T) {
+	hasAnno := func(rt *v2.ResourceType, msg proto.Message) bool {
+		annos := annotations.Annotations(rt.GetAnnotations())
+		return annos.Contains(msg)
+	}
+
+	cases := []struct {
+		name                         string
+		skipBaseRole, skipCustomRole bool
+		wantSkipAll                  bool
+	}{
+		{"both synced", false, false, false},
+		{"only base role synced", false, true, false},
+		{"only custom role synced", true, false, false},
+		{"neither synced", true, true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := NewUserBuilder(nil, tc.skipBaseRole, tc.skipCustomRole).ResourceType(context.Background())
+
+			if tc.wantSkipAll {
+				if !hasAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+					t.Errorf("want SkipEntitlementsAndGrants, got %v", rt.GetAnnotations())
+				}
+			} else {
+				if !hasAnno(rt, &v2.SkipEntitlements{}) {
+					t.Errorf("want SkipEntitlements, got %v", rt.GetAnnotations())
+				}
+				if hasAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+					t.Errorf("grants pass must not be skipped, got %v", rt.GetAnnotations())
+				}
+			}
+		})
+	}
+
+	// Both branches annotate, so a dropped proto.Clone would leak either one
+	// onto the shared package-level value.
+	if hasAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) || hasAnno(userResourceType, &v2.SkipEntitlements{}) {
+		t.Error("package-level userResourceType was mutated")
+	}
 }
 
 func TestIncidentClient_GetUsers_RequestDetails(t *testing.T) {

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -134,7 +134,7 @@ func TestUserBuilder_Grants_RespectsSyncFilter(t *testing.T) {
 
 	t.Run("both role types synced emits both grants", func(t *testing.T) {
 		testClient := newSingleUserTestClient()
-		builder := NewUserBuilder(testClient, true, true)
+		builder := NewUserBuilder(testClient, false, false)
 
 		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
 		if err != nil {
@@ -151,7 +151,7 @@ func TestUserBuilder_Grants_RespectsSyncFilter(t *testing.T) {
 
 	t.Run("neither role type synced emits no grants", func(t *testing.T) {
 		testClient := newSingleUserTestClient()
-		builder := NewUserBuilder(testClient, false, false)
+		builder := NewUserBuilder(testClient, true, true)
 
 		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
 		if err != nil {
@@ -165,7 +165,7 @@ func TestUserBuilder_Grants_RespectsSyncFilter(t *testing.T) {
 
 	t.Run("only base role synced emits only base-role grant", func(t *testing.T) {
 		testClient := newSingleUserTestClient()
-		builder := NewUserBuilder(testClient, true, false)
+		builder := NewUserBuilder(testClient, false, true)
 
 		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
 		if err != nil {

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/conductorone/baton-incident-io/pkg/client"
 	"github.com/conductorone/baton-incident-io/pkg/test"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
@@ -78,6 +80,105 @@ func TestIncidentClient_GetUsers(t *testing.T) {
 	if nextOptions == nil {
 		t.Fatal("Expected non-nil nextOptions")
 	}
+}
+
+const singleUserMockJSON = `{
+	"user": {
+		"id": "01JPWQNM50YGKQYFJYW61BBPD7",
+		"name": "test",
+		"email": "test@example.com",
+		"base_role": {
+			"id": "01JPWQNJKADS4VZ8PEYV0PAQPA",
+			"name": "Owner",
+			"description": "A base role managed by incident.io for owners of your account.",
+			"slug": "owner"
+		},
+		"custom_roles": [
+			{
+				"id": "01JPWQNJKAC407555HM47MP2V9",
+				"name": "Custom Responder",
+				"description": "A custom role.",
+				"slug": "custom-responder"
+			}
+		]
+	}
+}`
+
+func newSingleUserTestClient() *client.APIClient {
+	mockResponse := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(singleUserMockJSON)),
+	}
+	mockResponse.Header.Set("Content-Type", "application/json")
+
+	return test.NewTestClient(mockResponse, nil)
+}
+
+func hasGrantForResourceType(grants []*v2.Grant, resourceType string) bool {
+	for _, g := range grants {
+		if g.GetEntitlement().GetResource().GetId().GetResourceType() == resourceType {
+			return true
+		}
+	}
+	return false
+}
+
+func TestUserBuilder_Grants_RespectsSyncFilter(t *testing.T) {
+	userResource := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: "user",
+			Resource:     "01JPWQNM50YGKQYFJYW61BBPD7",
+		},
+	}
+
+	t.Run("both role types synced emits both grants", func(t *testing.T) {
+		testClient := newSingleUserTestClient()
+		builder := NewUserBuilder(testClient, true, true)
+
+		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if !hasGrantForResourceType(grants, "base-role") {
+			t.Errorf("Expected a base-role grant, got %+v", grants)
+		}
+		if !hasGrantForResourceType(grants, "custom-role") {
+			t.Errorf("Expected a custom-role grant, got %+v", grants)
+		}
+	})
+
+	t.Run("neither role type synced emits no grants", func(t *testing.T) {
+		testClient := newSingleUserTestClient()
+		builder := NewUserBuilder(testClient, false, false)
+
+		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if len(grants) != 0 {
+			t.Errorf("Expected zero grants, got %+v", grants)
+		}
+	})
+
+	t.Run("only base role synced emits only base-role grant", func(t *testing.T) {
+		testClient := newSingleUserTestClient()
+		builder := NewUserBuilder(testClient, true, false)
+
+		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if !hasGrantForResourceType(grants, "base-role") {
+			t.Errorf("Expected a base-role grant, got %+v", grants)
+		}
+		if hasGrantForResourceType(grants, "custom-role") {
+			t.Errorf("Expected no custom-role grant, got %+v", grants)
+		}
+	})
 }
 
 func TestIncidentClient_GetUsers_RequestDetails(t *testing.T) {

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -2,7 +2,6 @@ package connector
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"reflect"
@@ -159,22 +158,6 @@ func TestUserBuilder_Grants_RespectsSyncFilter(t *testing.T) {
 		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
-		}
-
-		if len(grants) != 0 {
-			t.Errorf("Expected zero grants, got %+v", grants)
-		}
-	})
-
-	t.Run("neither role type synced skips the user fetch", func(t *testing.T) {
-		// A transport that always errors: if Grants still succeeds, it never
-		// issued the per-user request whose result it would have discarded.
-		testClient := test.NewTestClient(nil, errors.New("unexpected API call"))
-		builder := NewUserBuilder(testClient, true, true)
-
-		grants, _, err := builder.Grants(context.Background(), userResource, resource.SyncOpAttrs{})
-		if err != nil {
-			t.Fatalf("Expected no API call, got error %v", err)
 		}
 
 		if len(grants) != 0 {


### PR DESCRIPTION
Gates cross-type grant emission from the user syncer on the customer's sync
filter, so grants aren't emitted for a resource type the sync excludes.
Reference: ConductorOne/baton-linear#55.

Each target is guarded individually in Grants(); when every target is excluded
the user resource type is annotated SkipEntitlementsAndGrants so the SDK skips
the pass entirely.

Flags are named skip<Type>ResourceType and stored inverted so the zero value
means "sync everything" — main.go registers a zero-value Connector{} as the
capabilities factory, bypassing New.

Build, tests, and golangci-lint (0 issues) pass.
